### PR TITLE
Padroniza layout e estilo das calculadoras

### DIFF
--- a/braden.html
+++ b/braden.html
@@ -5,17 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Enf-Escalas - Escala de Braden</title>
     <link rel="stylesheet" href="style.css">
-     <link rel="stylesheet" href="calculadoras.css">
+    <link rel="stylesheet" href="calculadoras.css">
 </head>
 <body>
 
     <header>
-        <h1>Enf-Escalas</h1>
-        <p>Suas ferramentas de avaliação de enfermagem, baseadas em evidências.</p>
+        <div class="header-content">
+            <h1>Enf-Escalas</h1>
+            <p>Suas ferramentas de avaliação de enfermagem, baseadas em evidências.</p>
+        </div>
+        <div class="header-controls">
+            <button id="dark-mode-toggle" aria-label="Alternar modo noturno">🌙</button>
+        </div>
     </header>
 
     <main>
-        <div class="escala-container">
+        <div class="calculadora-container">
             <h2>Escala de Braden</h2>
             <p>Avalia o risco do paciente para desenvolvimento de Lesão por Pressão (LPP).</p>
 
@@ -104,6 +109,8 @@
     <footer>
         <p>&copy; 2025 Enf-Escalas. Desenvolvido para auxiliar profissionais da saúde...</p>
     </footer>
-<script src="braden.js"></script>
-    </body>
+
+    <script src="script.js"></script>
+    <script src="braden.js"></script>
+</body>
 </html>

--- a/calculadoras.css
+++ b/calculadoras.css
@@ -1,12 +1,11 @@
-
-
 /* --- Container Principal da Calculadora --- */
 .calculadora-container {
     padding: 1.5rem;
     background-color: var(--cor-card);
     border-radius: 8px;
     box-shadow: 0 4px 8px var(--cor-sombra);
-    margin-top: 1rem;
+    margin: 2rem auto;
+    max-width: 800px;
 }
 
 @media (min-width: 768px) {
@@ -69,7 +68,7 @@
 }
 
 .btn-recalcular {
-    background-color: #6c757d; /* Cinza secundário */
+    background-color: #6c757d;
     margin-top: 1rem;
 }
 
@@ -84,7 +83,7 @@
     border-radius: 8px;
     text-align: center;
     font-size: 1.2rem;
-    display: none; /* Oculto por padrão, ativado via JS */
+    display: none;
 }
 
 #resultado strong {
@@ -93,7 +92,7 @@
     margin-bottom: 0.5rem;
 }
 
-/* Cores de fundo do resultado (harmonizadas com o tema) */
+/* Cores de fundo do resultado */
 .resultado-grave, .resultado-alto {
     background-color: #fdd8d8;
     color: #9b2c2c;
@@ -109,7 +108,7 @@
 
 /* --- Tabela (para RASS, etc.) --- */
 .tabela-container {
-    overflow-x: auto; /* Permite rolagem horizontal em telas pequenas */
+    overflow-x: auto;
 }
 
 .escala-tabela {
@@ -141,10 +140,61 @@
 }
 
 body.dark-mode .escala-tabela tbody tr.selected {
-    color: #1a202c; /* Texto escuro no highlight claro */
+    color: #1a202c;
 }
 
 body.dark-mode .escala-tabela th,
 body.dark-mode .escala-tabela td {
     border-bottom: 1px solid #4a5568;
+}
+
+/* --- Link de retorno --- */
+.link-voltar {
+    display: block;
+    text-align: center;
+    margin-top: 2rem;
+}
+
+/* --- Agrupamento de radio buttons --- */
+.radio-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+/* --- Descrição da escala --- */
+.escala-descricao {
+    margin-bottom: 1.5rem;
+}
+
+/* --- Ações fixas no rodapé --- */
+.sticky-footer-action {
+    position: sticky;
+    bottom: 0;
+    padding-top: 1rem;
+    background-color: var(--cor-card);
+}
+
+/* --- Layout específico para o Índice de Charlson --- */
+.comorbidities-grid {
+    display: grid;
+    gap: 0.5rem 1.5rem;
+}
+
+.checkbox-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0;
+}
+
+.checkbox-item input[type="checkbox"] {
+    width: auto;
+    flex-shrink: 0;
+}
+
+@media (min-width: 768px) {
+    .comorbidities-grid {
+        grid-template-columns: 1fr 1fr;
+    }
 }

--- a/charlson.html
+++ b/charlson.html
@@ -5,43 +5,24 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Índice de Charlson - Enf-Escalas</title>
     <link rel="stylesheet" href="style.css">
-       <link rel="stylesheet" href="calculadoras.css">
-
-    <style>
-        /* Estilo adicional para organizar os checkboxes em colunas em telas maiores */
-        .comorbidities-grid {
-            display: grid;
-            gap: 0.5rem 1.5rem;
-        }
-        .checkbox-item {
-            display: flex;
-            align-items: center;
-            gap: 0.75rem; /* Espaçamento entre o checkbox e o texto */
-            padding: 0.5rem 0;
-        }
-        .checkbox-item input[type="checkbox"] {
-            width: auto; /* Remove a largura de 100% dos checkboxes */
-            flex-shrink: 0;
-        }
-
-        @media (min-width: 768px) {
-            .comorbidities-grid {
-                grid-template-columns: 1fr 1fr; /* Duas colunas em tablets e desktops */
-            }
-        }
-    </style>
+    <link rel="stylesheet" href="calculadoras.css">
 </head>
 <body>
 
     <header>
-        <h1>Enf-Escalas</h1>
-        <p>Índice de Comorbidade de Charlson</p>
+        <div class="header-content">
+            <h1>Enf-Escalas</h1>
+            <p>Suas ferramentas de avaliação de enfermagem, baseadas em evidências.</p>
+        </div>
+        <div class="header-controls">
+            <button id="dark-mode-toggle" aria-label="Alternar modo noturno">🌙</button>
+        </div>
     </header>
 
     <main>
         <div class="calculadora-container">
-            <h2>Calculadora do Índice de Charlson</h2>
-            <p>Selecione a idade e as comorbidades do paciente para calcular o índice e estimar a sobrevida em 10 anos.</p>
+            <h2>Índice de Charlson</h2>
+            <p class="escala-descricao">Selecione a idade e as comorbidades do paciente para calcular o índice e estimar a sobrevida em 10 anos.</p>
             
             <form id="charlson-form" novalidate>
                 
@@ -84,13 +65,14 @@
 
             <div id="resultado" style="display: none;"></div>
         </div>
-<a href="index.html" class="link-voltar">← Voltar para a página inicial</a>
+        <a href="index.html" class="link-voltar">← Voltar para a página inicial</a>
     </main>
 
     <footer>
         <p>&copy; 2025 Enf-Escalas. Desenvolvido para auxiliar profissionais da saúde.</p>
     </footer>
 
+    <script src="script.js"></script>
     <script src="charlson.js"></script>
 </body>
 </html>

--- a/delirium.html
+++ b/delirium.html
@@ -10,12 +10,17 @@
 <body>
 
     <header>
-        <h1>Enf-Escalas</h1>
-        <p>Suas ferramentas de avaliação de enfermagem, baseadas em evidências.</p>
+        <div class="header-content">
+            <h1>Enf-Escalas</h1>
+            <p>Suas ferramentas de avaliação de enfermagem, baseadas em evidências.</p>
+        </div>
+        <div class="header-controls">
+            <button id="dark-mode-toggle" aria-label="Alternar modo noturno">🌙</button>
+        </div>
     </header>
 
     <main>
-        <div class="escala-container">
+        <div class="calculadora-container">
             <div id="choice-container">
                 <h2>Avaliação de Delirium</h2>
                 <p>Selecione a ferramenta apropriada para o seu ambiente clínico.</p>
@@ -115,7 +120,8 @@
     <footer>
         <p>&copy; 2025 Enf-Escalas. Desenvolvido para auxiliar profissionais da saúde...</p>
     </footer>
-    
+
+    <script src="script.js"></script>
     <script src="delirium.js"></script>
 </body>
 </html>

--- a/dor.html
+++ b/dor.html
@@ -5,16 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ferramenta - Escala de Dor</title>
     <link rel="stylesheet" href="style.css">
-       <link rel="stylesheet" href="calculadoras.css">
+    <link rel="stylesheet" href="calculadoras.css">
 </head>
 <body>
 
     <header>
-        <h1>Escala Visual Numérica de Dor (EVN)</h1>
+        <div class="header-content">
+            <h1>Enf-Escalas</h1>
+            <p>Suas ferramentas de avaliação de enfermagem, baseadas em evidências.</p>
+        </div>
+        <div class="header-controls">
+            <button id="dark-mode-toggle" aria-label="Alternar modo noturno">🌙</button>
+        </div>
     </header>
 
     <main>
-        <div class="escala-container">
+        <div class="calculadora-container">
+            <h2>Escala Visual Numérica de Dor (EVN)</h2>
             <p class="escala-descricao">
                 Selecione o número que melhor representa a intensidade da dor do paciente.
             </p>
@@ -34,6 +41,7 @@
         <p>&copy; 2025 Enf-Escalas.</p>
     </footer>
 
+    <script src="script.js"></script>
     <script src="dor.js"></script>
 </body>
 </html>

--- a/glasgow.html
+++ b/glasgow.html
@@ -5,72 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Calculadora - Escala de Glasgow</title>
     <link rel="stylesheet" href="style.css">
-     <link rel="stylesheet" href="calculadoras.css">
-    <style>
-        .calculadora-container {
-            max-width: 800px;
-            margin: 2rem auto;
-            padding: 2rem;
-            background-color: var(--cor-card);
-            border-radius: 8px;
-            box-shadow: 0 4px 8px var(--cor-sombra);
-        }
-        .form-group {
-            margin-bottom: 1.5rem;
-        }
-        .form-group label {
-            display: block;
-            margin-bottom: 0.5rem;
-            font-weight: bold;
-        }
-        .form-group select {
-            width: 100%;
-            padding: 0.8rem;
-            border: 1px solid #ccc;
-            border-radius: 4px;
-            font-size: 1rem;
-        }
-        .btn-calcular {
-            width: 100%;
-            padding: 1rem;
-            font-size: 1.2rem;
-            font-weight: bold;
-            color: white;
-            background-color: var(--cor-primaria);
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            transition: background-color 0.2s;
-        }
-        .btn-calcular:hover {
-            background-color: #0056b3;
-        }
-        #resultado {
-            margin-top: 2rem;
-            padding: 1.5rem;
-            border-radius: 8px;
-            text-align: center;
-            font-size: 1.5rem;
-            display: none; /* O resultado só aparece depois do cálculo */
-        }
-        .resultado-grave { background-color: #f8d7da; color: #721c24; }
-        .resultado-moderado { background-color: #fff3cd; color: #856404; }
-        .resultado-leve { background-color: #d4edda; color: #155724; }
-        .link-voltar {
-            display: block;
-            text-align: center;
-            margin-top: 2rem;
-        }
-    </style>
+    <link rel="stylesheet" href="calculadoras.css">
 </head>
 <body>
 
     <header>
-        <h1>Escala de Coma de Glasgow</h1>
+        <div class="header-content">
+            <h1>Enf-Escalas</h1>
+            <p>Suas ferramentas de avaliação de enfermagem, baseadas em evidências.</p>
+        </div>
+        <div class="header-controls">
+            <button id="dark-mode-toggle" aria-label="Alternar modo noturno">🌙</button>
+        </div>
     </header>
 
     <main>
         <div class="calculadora-container">
+            <h2>Escala de Coma de Glasgow</h2>
             <form id="glasgow-form">
                 <div class="form-group">
                     <label for="ocular">Resposta Ocular (O)</label>
@@ -108,8 +59,7 @@
                 <button type="submit" class="btn-calcular">Calcular Pontuação</button>
             </form>
 
-            <div id="resultado">
-                </div>
+            <div id="resultado"></div>
         </div>
         <a href="index.html" class="link-voltar">← Voltar para a página inicial</a>
     </main>
@@ -118,6 +68,7 @@
         <p>&copy; 2025 Enf-Escalas.</p>
     </footer>
 
+    <script src="script.js"></script>
     <script src="glasgow.js"></script>
 </body>
 </html>

--- a/katz.html
+++ b/katz.html
@@ -5,16 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Calculadora - Índice de Katz</title>
     <link rel="stylesheet" href="style.css">
-     <link rel="stylesheet" href="calculadoras.css">
+    <link rel="stylesheet" href="calculadoras.css">
 </head>
 <body>
 
     <header>
-        <h1>Índice de Katz de Independência nas Atividades da Vida Diária</h1>
+        <div class="header-content">
+            <h1>Enf-Escalas</h1>
+            <p>Suas ferramentas de avaliação de enfermagem, baseadas em evidências.</p>
+        </div>
+        <div class="header-controls">
+            <button id="dark-mode-toggle" aria-label="Alternar modo noturno">🌙</button>
+        </div>
     </header>
 
     <main>
         <div class="calculadora-container">
+            <h2>Índice de Katz</h2>
             <p class="escala-descricao">
                 Avalie a capacidade do paciente em realizar cada uma das atividades abaixo sem supervisão, direção ou assistência pessoal.
             </p>
@@ -82,6 +89,7 @@
         <p>&copy; 2025 Enf-Escalas.</p>
     </footer>
 
+    <script src="script.js"></script>
     <script src="katz.js"></script>
 </body>
 </html>

--- a/mews.html
+++ b/mews.html
@@ -5,16 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Calculadora - Escala MEWS</title>
     <link rel="stylesheet" href="style.css">
-     <link rel="stylesheet" href="calculadoras.css">
+    <link rel="stylesheet" href="calculadoras.css">
 </head>
 <body>
 
     <header>
-        <h1>Calculadora da Escala MEWS</h1>
+        <div class="header-content">
+            <h1>Enf-Escalas</h1>
+            <p>Suas ferramentas de avaliação de enfermagem, baseadas em evidências.</p>
+        </div>
+        <div class="header-controls">
+            <button id="dark-mode-toggle" aria-label="Alternar modo noturno">🌙</button>
+        </div>
     </header>
 
     <main>
         <div class="calculadora-container">
+            <h2>Escala MEWS</h2>
             <p class="escala-descricao">
                 Insira os parâmetros fisiológicos do paciente para calcular o escore de alerta precoce.
             </p>
@@ -64,6 +71,7 @@
         <p>&copy; 2025 Enf-Escalas.</p>
     </footer>
 
+    <script src="script.js"></script>
     <script src="mews.js"></script>
 </body>
 </html>

--- a/morse.html
+++ b/morse.html
@@ -5,16 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Calculadora - Escala de Morse</title>
     <link rel="stylesheet" href="style.css">
-     <link rel="stylesheet" href="calculadoras.css">
+    <link rel="stylesheet" href="calculadoras.css">
 </head>
 <body>
 
     <header>
-        <h1>Escala de Risco de Queda de Morse</h1>
+        <div class="header-content">
+            <h1>Enf-Escalas</h1>
+            <p>Suas ferramentas de avaliação de enfermagem, baseadas em evidências.</p>
+        </div>
+        <div class="header-controls">
+            <button id="dark-mode-toggle" aria-label="Alternar modo noturno">🌙</button>
+        </div>
     </header>
 
     <main>
         <div class="calculadora-container">
+            <h2>Escala de Morse</h2>
             <form id="morse-form">
                 
                 <div class="form-group">
@@ -80,6 +87,7 @@
         <p>&copy; 2025 Enf-Escalas.</p>
     </footer>
 
+    <script src="script.js"></script>
     <script src="morse.js"></script>
 </body>
 </html>

--- a/rass.html
+++ b/rass.html
@@ -5,16 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Guia - Escala RASS</title>
     <link rel="stylesheet" href="style.css">
-     <link rel="stylesheet" href="calculadoras.css">
+    <link rel="stylesheet" href="calculadoras.css">
 </head>
 <body>
 
     <header>
-        <h1>Escala de Agitação e Sedação de Richmond (RASS)</h1>
+        <div class="header-content">
+            <h1>Enf-Escalas</h1>
+            <p>Suas ferramentas de avaliação de enfermagem, baseadas em evidências.</p>
+        </div>
+        <div class="header-controls">
+            <button id="dark-mode-toggle" aria-label="Alternar modo noturno">🌙</button>
+        </div>
     </header>
 
     <main>
-        <div class="escala-container">
+        <div class="calculadora-container">
+            <h2>Escala RASS</h2>
             <p class="escala-descricao">
                 Esta é uma ferramenta para avaliar o nível de agitação ou sedação de um paciente. Clique em uma linha para destacá-la.
             </p>
@@ -89,6 +96,7 @@
         <p>&copy; 2025 Enf-Escalas.</p>
     </footer>
 
+    <script src="script.js"></script>
     <script src="rass.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -4,67 +4,73 @@ document.addEventListener('DOMContentLoaded', () => {
     const darkModeToggle = document.getElementById('dark-mode-toggle');
     const body = document.body;
 
-    if (localStorage.getItem('dark-mode') === 'enabled') {
-        body.classList.add('dark-mode');
-        darkModeToggle.textContent = '☀️';
-    }
-
-    darkModeToggle.addEventListener('click', () => {
-        body.classList.toggle('dark-mode');
-        if (body.classList.contains('dark-mode')) {
-            localStorage.setItem('dark-mode', 'enabled');
+    if (darkModeToggle) {
+        if (localStorage.getItem('dark-mode') === 'enabled') {
+            body.classList.add('dark-mode');
             darkModeToggle.textContent = '☀️';
-        } else {
-            localStorage.setItem('dark-mode', 'disabled');
-            darkModeToggle.textContent = '🌙';
         }
-    });
+
+        darkModeToggle.addEventListener('click', () => {
+            body.classList.toggle('dark-mode');
+            if (body.classList.contains('dark-mode')) {
+                localStorage.setItem('dark-mode', 'enabled');
+                darkModeToggle.textContent = '☀️';
+            } else {
+                localStorage.setItem('dark-mode', 'disabled');
+                darkModeToggle.textContent = '🌙';
+            }
+        });
+    }
 
     // --- LÓGICA DA BUSCA ---
     const searchBox = document.getElementById('search-box');
     const escalaCards = document.querySelectorAll('.escala-card');
 
-    searchBox.addEventListener('input', (e) => {
-        const searchTerm = e.target.value.toLowerCase().trim();
-        escalaCards.forEach(card => {
-            const title = card.dataset.title.toLowerCase();
-            if (title.includes(searchTerm)) {
-                card.parentElement.style.display = 'block'; // Mostra a seção que contém o card
-            } else {
-                card.parentElement.style.display = 'none'; // Esconde a seção
-            }
+    if (searchBox) {
+        searchBox.addEventListener('input', (e) => {
+            const searchTerm = e.target.value.toLowerCase().trim();
+            escalaCards.forEach(card => {
+                const title = card.dataset.title.toLowerCase();
+                if (title.includes(searchTerm)) {
+                    card.parentElement.style.display = 'block';
+                } else {
+                    card.parentElement.style.display = 'none';
+                }
+            });
         });
-    });
+    }
 
     // --- LÓGICA DO MODAL DE INFORMAÇÕES ---
     const infoModal = document.getElementById('info-modal');
     const modalBody = document.getElementById('modal-body');
     const modalCloseBtn = document.getElementById('modal-close-btn');
 
-    document.querySelectorAll('.info-btn').forEach(button => {
-        button.addEventListener('click', (e) => {
-            e.stopPropagation();
-            e.preventDefault();
-            const infoId = button.dataset.infoId;
-            const content = document.getElementById(infoId);
-            if (content) {
-                modalBody.innerHTML = content.innerHTML;
-                infoModal.style.display = 'flex';
+    if (infoModal && modalBody && modalCloseBtn) {
+        document.querySelectorAll('.info-btn').forEach(button => {
+            button.addEventListener('click', (e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                const infoId = button.dataset.infoId;
+                const content = document.getElementById(infoId);
+                if (content) {
+                    modalBody.innerHTML = content.innerHTML;
+                    infoModal.style.display = 'flex';
+                }
+            });
+        });
+
+        const closeModal = () => {
+            infoModal.style.display = 'none';
+            modalBody.innerHTML = '';
+        };
+
+        modalCloseBtn.addEventListener('click', closeModal);
+        infoModal.addEventListener('click', (e) => {
+            if (e.target === infoModal) {
+                closeModal();
             }
         });
-    });
-
-    const closeModal = () => {
-        infoModal.style.display = 'none';
-        modalBody.innerHTML = '';
-    };
-
-    modalCloseBtn.addEventListener('click', closeModal);
-    infoModal.addEventListener('click', (e) => {
-        if (e.target === infoModal) {
-            closeModal();
-        }
-    });
+    }
 
     // --- REGISTRO DO SERVICE WORKER (PWA) ---
     if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- Usa um cabeçalho unificado com modo noturno em todas as calculadoras
- Centraliza estilos em `calculadoras.css` e remove CSS inline
- Ajusta `script.js` para funcionar mesmo sem elementos opcionais

## Testing
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e68997bdc832eb06638217238c846